### PR TITLE
Fix for running MariaDB 10.6

### DIFF
--- a/Model/DashboardRow/MySQLSettings.php
+++ b/Model/DashboardRow/MySQLSettings.php
@@ -77,6 +77,7 @@ class MySQLSettings extends DashboardRow implements DashboardRowInterface
         $info = '';
         foreach ($this->defaultValues as $key => $value) {
             $currentValue = $connection->fetchRow('SHOW VARIABLES LIKE \'' . $key . '\'');
+            if (is_array($currentValue) == false) continue;
             if ($currentValue['Value'] <= $value) {
                 $this->problems .= $key . ' lower than - or equal to the default value: '
                     . $currentValue['Value'];


### PR DESCRIPTION
The 'innodb_thread_concurrency' variable has been dropped from version 10.6 of MariaDB. The dashboard doesn't display after you update to this version. 


https://mariadb.com/docs/server/ref/mdb/system-variables/innodb_thread_concurrency/